### PR TITLE
Update the version of the Vert.x Forge Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
       <version.forge>3.5.0.Final</version.forge>
       <version.wildfly-swarm>2017.2.0</version.wildfly-swarm>
       <version.fabric8.devops>2.3.80</version.fabric8.devops>
-      <version.vertx>1.1.0</version.vertx>
+      <version.vertx>1.2.1</version.vertx>
 
       <maven.compiler.source>1.8</maven.compiler.source>
       <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
This new version supports Vert.x 3.4.0.Beta1 (version used in the latest versions of the quickstarts)